### PR TITLE
Add support for newly found BRCAD fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "flour"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "bytestream",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flour"
 description = "Serializes and deserializes BCCAD / BRCAD files to and from JSON"
 authors = ["patataofcourse"]
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 
 readme = "README.md"

--- a/src/bxcad/brcad.rs
+++ b/src/bxcad/brcad.rs
@@ -43,7 +43,8 @@ pub struct BRCAD {
 impl BRCAD {
     /// Get whether or not associated texture sheet has variations, like in Flock Step
     ///
-    /// If true, textures must be paletted; if false, textures must not be paletted
+    /// If true, textures must be paletted; if false, textures must not be paletted. For Flock Step's birds,
+    /// this value is overwritten by the game
     #[allow(deprecated)]
     pub fn has_variations(&self) -> bool {
         if cfg!(target_endian = "big") {
@@ -55,7 +56,8 @@ impl BRCAD {
 
     /// Get whether or not associated texture sheet has variations, like in Flock Step (mutable)
     ///
-    /// If true, textures must be paletted; if false, textures must not be paletted
+    /// If true, textures must be paletted; if false, textures must not be paletted. For Flock Step's birds,
+    /// this value is overwritten by the game
     pub fn has_variations_mut(&mut self) -> &mut bool {
         #[allow(deprecated)]
         let ptr = &mut self.unk0 as *mut u32 as *mut u8 as *mut bool;

--- a/src/bxcad/brcad.rs
+++ b/src/bxcad/brcad.rs
@@ -20,7 +20,7 @@ pub struct BRCAD {
     /// Boolean value that tests whether or not the associated texture sheet has variations.
     /// Use [`has_variations`] or [`has_variations_mut`] instead
     #[deprecated(since = "2.1.0", note = "use has_variations instead")]
-    #[serde(rename = "use_variation", alias = "unk0", with = "use_variation")]
+    #[serde(rename = "has_variations", alias = "unk0", with = "use_variation")]
     pub unk0: u32,
     /// Number of the spritesheet to use in a specific
     pub spritesheet_num: u16,

--- a/src/bxcad/brcad.rs
+++ b/src/bxcad/brcad.rs
@@ -87,7 +87,7 @@ pub struct Animation {
 /// whole animation
 #[derive(Serialize, Deserialize, Clone)]
 pub struct AnimationStep {
-    /// A reference to the index number of the [`Sprite`] this AnimationStep uses
+    /// A reference to the index number of the [Sprite] this AnimationStep uses
     pub sprite: u16,
     /// Duration of the step (FPS is variable)
     pub duration: u16,

--- a/src/bxcad/mod.rs
+++ b/src/bxcad/mod.rs
@@ -11,6 +11,9 @@ pub mod bccad;
 /// Everything related to the BRCAD format used in Rhythm Heaven Fever
 pub mod brcad;
 
+/// Custom implementations for (de)serialization
+mod serde_impl;
+
 /// QoL features for the JSON format
 #[cfg(feature = "modder_qol")]
 pub mod qol;

--- a/src/bxcad/qol.rs
+++ b/src/bxcad/qol.rs
@@ -102,6 +102,7 @@ impl Indexizable for brcad::BRCAD {
 
         IndexizedBRCAD {
             timestamp: self.timestamp,
+            #[allow(deprecated)]
             unk0: self.unk0,
             spritesheet_num: self.spritesheet_num,
             spritesheet_control: self.spritesheet_control,
@@ -128,6 +129,7 @@ impl Indexizable for brcad::BRCAD {
             sprites.push(sprite);
         }
 
+        #[allow(deprecated)]
         Self {
             timestamp: og.timestamp,
             unk0: og.unk0,

--- a/src/bxcad/serde_impl.rs
+++ b/src/bxcad/serde_impl.rs
@@ -1,0 +1,183 @@
+/// Implementation for BRCAD AnimationStep pos_x and pos_y serialization in flour 2.1+
+pub mod pos_xy {
+    use crate::bxcad::brcad::AnimationStep;
+    use serde::{
+        de::{Error, SeqAccess, Unexpected, Visitor},
+        ser::SerializeSeq,
+        Deserializer, Serializer,
+    };
+
+    struct PosXYVisitor;
+
+    const UNEXPECTED: &str = "a sequence of two 16-bit signed integers or a 32-bit integer";
+
+    impl<'de> Visitor<'de> for PosXYVisitor {
+        type Value = u32;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "{}", UNEXPECTED)
+        }
+
+        // 1.0 - 2.0 behavior
+
+        fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> {
+            Ok(v)
+        }
+
+        fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> {
+            Ok(v as u32)
+        }
+
+        fn visit_u64<E: Error>(self, v: u64) -> Result<Self::Value, E> {
+            let Ok(v) = v.try_into() else {
+                Err(E::invalid_type(Unexpected::Unsigned(v), &UNEXPECTED))?
+            };
+            self.visit_u32(v)
+        }
+
+        fn visit_i64<E: Error>(self, v: i64) -> Result<Self::Value, E> {
+            let Ok(v) = v.try_into() else {
+                Err(E::invalid_type(Unexpected::Signed(v), &UNEXPECTED))?
+            };
+            self.visit_i32(v)
+        }
+
+        // 2.1+ behavior
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let mut out = 0u32;
+
+            let Some(pos_x) = seq.next_element::<i16>()? else {
+                Err(A::Error::invalid_length(0, &"2"))?
+            };
+            let Some(pos_y) = seq.next_element::<i16>()? else {
+                Err(A::Error::invalid_length(1, &"2"))?
+            };
+
+            // this way we can catch some errors where there's too many values
+            if let Some(size) = seq.size_hint() {
+                if size != 2 {
+                    Err(A::Error::invalid_length(size + 2, &"2"))?;
+                }
+            }
+
+            *AnimationStep::get_pos_mut(&mut out, false) = pos_x;
+            *AnimationStep::get_pos_mut(&mut out, true) = pos_y;
+            Ok(out)
+        }
+    }
+
+    pub fn serialize<S: Serializer>(value: &u32, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&AnimationStep::get_pos(value, false))?;
+        seq.serialize_element(&AnimationStep::get_pos(value, true))?;
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
+        deserializer.deserialize_any(PosXYVisitor)
+    }
+}
+
+/// Implementation for BRCAD has_texture serialization in flour 2.1+
+pub mod use_variation {
+    use serde::{
+        de::{Error, Unexpected, Visitor},
+        Deserializer, Serializer,
+    };
+
+    struct UseVariationVisitor;
+
+    const UNEXPECTED: &str = "a boolean or 32-bit integer";
+
+    impl<'de> Visitor<'de> for UseVariationVisitor {
+        type Value = u32;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "{}", UNEXPECTED)
+        }
+
+        // 1.0 - 2.0 behavior
+
+        fn visit_u32<E: Error>(self, v: u32) -> Result<Self::Value, E> {
+            Ok(v)
+        }
+
+        fn visit_i32<E: Error>(self, v: i32) -> Result<Self::Value, E> {
+            Ok(v as u32)
+        }
+
+        fn visit_u64<E: Error>(self, v: u64) -> Result<Self::Value, E> {
+            let Ok(v) = v.try_into() else {
+                Err(E::invalid_type(Unexpected::Unsigned(v), &UNEXPECTED))?
+            };
+            self.visit_u32(v)
+        }
+
+        fn visit_i64<E: Error>(self, v: i64) -> Result<Self::Value, E> {
+            let Ok(v) = v.try_into() else {
+                Err(E::invalid_type(Unexpected::Signed(v), &UNEXPECTED))?
+            };
+            self.visit_i32(v)
+        }
+
+        // 2.1+ behavior
+
+        fn visit_bool<E: Error>(self, v: bool) -> Result<Self::Value, E> {
+            Ok(v as u32)
+        }
+    }
+
+    pub fn serialize<S: Serializer>(value: &u32, serializer: S) -> Result<S::Ok, S::Error> {
+        if cfg!(target_endian = "big") {
+            serializer.serialize_bool(*value as u8 != 0)
+        } else {
+            serializer.serialize_bool((*value >> 24) as u8 != 0)
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
+        deserializer.deserialize_any(UseVariationVisitor)
+    }
+}
+
+pub mod variation_num {
+    use serde::{
+        de::{Error, Visitor},
+        Deserializer, Serializer,
+    };
+
+    pub struct VariationNumVisitor;
+
+    const UNEXPECTED: &str = "an integer";
+
+    impl<'de> Visitor<'de> for VariationNumVisitor {
+        type Value = u32;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "{}", UNEXPECTED)
+        }
+
+        fn visit_i64<E: Error>(self, v: i64) -> Result<Self::Value, E> {
+            self.visit_u64(v as u64)
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> {
+            let v = v as u32;
+
+            Ok(if v > u16::MAX as u32 { v >> 16 } else { v })
+        }
+    }
+
+    pub fn serialize<S: Serializer>(value: &u32, serializer: S) -> Result<S::Ok, S::Error> {
+        if cfg!(target_endian = "big") {
+            serializer.serialize_u16(*value as u16)
+        } else {
+            serializer.serialize_u16((*value >> 16) as u16)
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
+        deserializer.deserialize_any(VariationNumVisitor)
+    }
+}


### PR DESCRIPTION
Thanks to @conhlee for all the information! It's very much appreciated.

Old `unkX` fields have been deprecated in favor of methods that return the actual values. These deprecated fields will be replaced with new fields by the name of the current methods in a possible future flour v3.

Replaced fields:
- `BRCAD::unk0`-> `BRCAD::has_variations[_mut]`
- `SpritePart::unk` -> `SpritePart::variation_num[_mut]`
- `AnimationStep::unk0` -> `AnimationStep::pos_x[_mut]` and `AnimationStep::pos_y[_mut]`

In serializing, the new names and formats are used, but older serialized files will still be able to be read by 2.1+.

New information from the BRCAD specification has also been added.

TODO
- [x] Test if variation_num works properly on (de)serializing